### PR TITLE
Support extra co-ordinate values in JSON

### DIFF
--- a/lib/rgeo/geo_json/coder.rb
+++ b/lib/rgeo/geo_json/coder.rb
@@ -130,9 +130,6 @@ module RGeo
         else
           raise ::ArgumentError, "Unrecognzied json_parser: #{@json_parser.inspect}"
         end
-        @num_coordinates = 2
-        @num_coordinates += 1 if @geo_factory.property(:has_z_coordinate)
-        @num_coordinates += 1 if @geo_factory.property(:has_m_coordinate)
       end
       
       
@@ -224,15 +221,15 @@ module RGeo
         unless point_encoder_
           if object_.factory.property(:has_z_coordinate)
             if object_.factory.property(:has_m_coordinate)
-              point_encoder_ = ::Proc.new{ |p_| [p_.x, p_.y, p_.z, p_.m] }
+              point_encoder_ = ::Proc.new{ |p_| [p_.x, p_.y, p_.z, p_.m, *p_.extra] }
             else
-              point_encoder_ = ::Proc.new{ |p_| [p_.x, p_.y, p_.z] }
+              point_encoder_ = ::Proc.new{ |p_| [p_.x, p_.y, p_.z, *p_.extra] }
             end
           else
             if object_.factory.property(:has_m_coordinate)
-              point_encoder_ = ::Proc.new{ |p_| [p_.x, p_.y, p_.m] }
+              point_encoder_ = ::Proc.new{ |p_| [p_.x, p_.y, p_.m, *p_.extra] }
             else
-              point_encoder_ = ::Proc.new{ |p_| [p_.x, p_.y] }
+              point_encoder_ = ::Proc.new{ |p_| [p_.x, p_.y, *p_.extra] }
             end
           end
         end
@@ -324,7 +321,7 @@ module RGeo
       
       def _decode_point_coords(point_coords_)  # :nodoc:
         return nil unless point_coords_.kind_of?(::Array)
-        @geo_factory.point(*(point_coords_[0...@num_coordinates].map{ |c_| c_.to_f })) rescue nil
+        @geo_factory.point(*(point_coords_.map{ |c_| c_.to_f })) rescue nil
       end
       
       

--- a/test/tc_basic.rb
+++ b/test/tc_basic.rb
@@ -70,6 +70,17 @@ module RGeo
         end
         
         
+        def test_point_with_extra
+          object_ = @geo_factory.point(10, 20, 100, 101, 102)
+          json_ = {
+            'type' => 'Point',
+            'coordinates' => [10.0, 20.0, 100, 101, 102],
+          }
+          assert_equal(json_, ::RGeo::GeoJSON.encode(object_))
+          assert_equal([100, 101, 102], ::RGeo::GeoJSON.decode(json_, :geo_factory => @geo_factory).extra)
+        end
+        
+        
         def test_point_z
           object_ = @geo_factory_z.point(10, 20, -1)
           json_ = {
@@ -78,6 +89,17 @@ module RGeo
           }
           assert_equal(json_, ::RGeo::GeoJSON.encode(object_))
           assert(::RGeo::GeoJSON.decode(json_, :geo_factory => @geo_factory_z).eql?(object_))
+        end
+        
+        
+        def test_point_z_with_extra
+          object_ = @geo_factory_z.point(10, 20, -1, 100, 101, 102)
+          json_ = {
+            'type' => 'Point',
+            'coordinates' => [10.0, 20.0, -1.0, 100, 101, 102],
+          }
+          assert_equal(json_, ::RGeo::GeoJSON.encode(object_))
+          assert_equal([100, 101, 102], ::RGeo::GeoJSON.decode(json_, :geo_factory => @geo_factory_z).extra)
         end
         
         
@@ -92,6 +114,17 @@ module RGeo
         end
         
         
+        def test_point_m_with_extra
+          object_ = @geo_factory_m.point(10, 20, -1, 100, 101, 102)
+          json_ = {
+            'type' => 'Point',
+            'coordinates' => [10.0, 20.0, -1.0, 100, 101, 102],
+          }
+          assert_equal(json_, ::RGeo::GeoJSON.encode(object_))
+          assert_equal([100, 101, 102], ::RGeo::GeoJSON.decode(json_, :geo_factory => @geo_factory_m).extra)
+        end
+        
+        
         def test_point_zm
           object_ = @geo_factory_zm.point(10, 20, -1, -2)
           json_ = {
@@ -100,6 +133,17 @@ module RGeo
           }
           assert_equal(json_, ::RGeo::GeoJSON.encode(object_))
           assert(::RGeo::GeoJSON.decode(json_, :geo_factory => @geo_factory_zm).eql?(object_))
+        end
+        
+        
+        def test_point_zm_with_extra
+          object_ = @geo_factory_zm.point(10, 20, -1, -2, 100, 101, 102)
+          json_ = {
+            'type' => 'Point',
+            'coordinates' => [10.0, 20.0, -1.0, -2.0, 100, 101, 102],
+          }
+          assert_equal(json_, ::RGeo::GeoJSON.encode(object_))
+          assert_equal([100, 101, 102], ::RGeo::GeoJSON.decode(json_, :geo_factory => @geo_factory_zm).extra)
         end
         
         


### PR DESCRIPTION
Support extra co-ordinate values as per the GeoJSON specification. (Fixes #2)

This change depends on [this commit](https://github.com/lukeredpath/rgeo/commit/11370d546b16604c8ff1d09d4c704bde5e3c2d68) in my rgeo fork.