### PR TITLE
Make specs work with Ruby 2.0 and 2.1

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -68,6 +68,10 @@ platform_suffix_ =
       'mri18'
     elsif ::RUBY_VERSION =~ /^1\.9\..*$/
       'mri19'
+    elsif ::RUBY_VERSION =~ /^2\.0\..*$/
+      'mri20'
+    elsif ::RUBY_VERSION =~ /^2\.1\..*$/
+      'mri21'
     else
       raise "Unknown version of Matz Ruby Interpreter (#{::RUBY_VERSION})"
     end

--- a/rgeo-geojson.gemspec
+++ b/rgeo-geojson.gemspec
@@ -50,5 +50,6 @@
   s_.extra_rdoc_files = ::Dir.glob("*.rdoc")
   s_.test_files = ::Dir.glob("test/**/tc_*.rb")
   s_.platform = ::Gem::Platform::RUBY
+  s_.add_development_dependency("minitest", "~> 4.0")
   s_.add_dependency('rgeo', '>= 0.3.13')
 end

--- a/test/tc_basic.rb
+++ b/test/tc_basic.rb
@@ -34,7 +34,8 @@
 ;
 
 
-require 'test/unit'
+require 'minitest/autorun'
+require 'minitest/pride'
 require 'rgeo/geo_json'
 
 
@@ -42,7 +43,7 @@ module RGeo
   module GeoJSON
     module Tests  # :nodoc:
 
-      class TestGeoJSON < ::Test::Unit::TestCase  # :nodoc:
+      class TestGeoJSON < ::Minitest::Test  # :nodoc:
 
 
         def setup
@@ -55,7 +56,7 @@ module RGeo
 
 
         def test_has_version
-          assert_not_nil(::RGeo::GeoJSON::VERSION)
+          refute_nil(::RGeo::GeoJSON::VERSION)
         end
 
 
@@ -226,7 +227,7 @@ module RGeo
             'properties' => nil,
           }
           obj_ = ::RGeo::GeoJSON.decode(json_, :geo_factory => @geo_factory)
-          assert_not_nil(obj_)
+          refute_nil(obj_)
           assert_nil(obj_.geometry)
           assert_equal({}, obj_.properties)
         end


### PR DESCRIPTION
This PR makes it possible to develop against Ruby 2.1.1 locally.  The specs are passing with the below updates run against 2.1.1.  I'd be curious to see if ci passes as well.
- Update Rakefile to not error on unknown Ruby
- Add explicit minitest development dependency
- Require minitest in place of test/unit
- Make test output colorful
- Change assert_not_nil to refute_nil
