### PR TITLE
Make RGeo::GeoJSON.encode cope with null geometry

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -27,7 +27,7 @@ Metrics/LineLength:
 # Offense count: 11
 # Configuration parameters: CountComments.
 Metrics/MethodLength:
-  Max: 54
+  Max: 41
 
 # Offense count: 3
 Metrics/PerceivedComplexity:

--- a/lib/rgeo/geo_json/coder.rb
+++ b/lib/rgeo/geo_json/coder.rb
@@ -135,22 +135,7 @@ module RGeo
         json
       end
 
-      def _encode_geometry(object, point_encoder = nil) # :nodoc:
-        unless point_encoder
-          if object.factory.property(:has_z_coordinate)
-            if object.factory.property(:has_m_coordinate)
-              point_encoder = proc { |p| [p.x, p.y, p.z, p.m] }
-            else
-              point_encoder = proc { |p| [p.x, p.y, p.z] }
-            end
-          else
-            if object.factory.property(:has_m_coordinate)
-              point_encoder = proc { |p| [p.x, p.y, p.m] }
-            else
-              point_encoder = proc { |p| [p.x, p.y] }
-            end
-          end
-        end
+      def _encode_geometry(object) # :nodoc:
         case object
         when RGeo::Feature::Point
           {
@@ -185,7 +170,7 @@ module RGeo
         when RGeo::Feature::GeometryCollection
           {
             "type" => "GeometryCollection",
-            "geometries" => object.map { |geom| _encode_geometry(geom, point_encoder) },
+            "geometries" => object.map { |geom| _encode_geometry(geom) }
           }
         else
           nil

--- a/test/basic_test.rb
+++ b/test/basic_test.rb
@@ -162,11 +162,8 @@ class BasicTest < Minitest::Test # :nodoc:
   end
 
   def test_feature_nulls
-    json = {
-      "type" => "Feature",
-      "geometry" => nil,
-      "properties" => nil,
-    }
+    feature = @entity_factory.feature(nil, nil, nil)
+    json = RGeo::GeoJSON.encode(feature)
     obj_ = RGeo::GeoJSON.decode(json, geo_factory: @geo_factory)
     refute_nil(obj_)
     assert_nil(obj_.geometry)


### PR DESCRIPTION
GeoJSON's [feature object spec](http://geojson.org/geojson-spec.html#feature-objects)
states that null geometry is allowed as `"geometry": null`, but
`RGeo::GeoJSON::Coder#_encode_geometry` would not allow us to encode this
(it tries to dereference `NilClass#factory`). Remove the `point_encoder` assignments that are causing this. They became redundant in 1bb9df7ac739d1f60eae48785645e00ad46cfb96.