### PR TITLE
Rubocop explicit version/upgrade/rake task

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,6 @@ gem "ffi-geos", ">= 0.0.4"
 
 group :development, :test do
   gem "minitest", "~> 5.8"
-  gem "rubocop", "~> 0.35.1"
+  gem "rubocop", "~> 0.39"
   gem "rake", "~> 11.0"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,9 @@ source "https://rubygems.org"
 gemspec
 
 gem "ffi-geos", ">= 0.0.4"
+
+group :development, :test do
+  gem "minitest", "~> 5.8"
+  gem "rubocop", "~> 0.35.1"
+  gem "rake", "~> 11.0"
+end

--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,13 @@
 require "bundler/gem_tasks"
 require "rake/testtask"
+require "rubocop/rake_task"
 
-task default: [:test]
+task default: [:test, :rubocop]
 
 Rake::TestTask.new(:test) do |t|
   t.libs << "test"
   t.test_files = %w(test/**/*_test.rb)
   t.verbose = false
 end
+
+RuboCop::RakeTask.new

--- a/lib/rgeo/geo_json/coder.rb
+++ b/lib/rgeo/geo_json/coder.rb
@@ -220,7 +220,7 @@ module RGeo
 
       def _decode_point_coords(point_coords)  # :nodoc:
         return nil unless point_coords.is_a?(Array)
-        @geo_factory.point(*(point_coords[0...@num_coordinates].map(&:to_f))) rescue nil
+        @geo_factory.point(*point_coords[0...@num_coordinates].map(&:to_f)) rescue nil
       end
 
       def _decode_line_string_coords(line_coords) # :nodoc:
@@ -246,7 +246,7 @@ module RGeo
           ring = @geo_factory.linear_ring(points)
           rings << ring if ring
         end
-        if rings.size == 0
+        if rings.empty?
           nil
         else
           @geo_factory.polygon(rings[0], rings[1..-1])

--- a/rgeo-geojson.gemspec
+++ b/rgeo-geojson.gemspec
@@ -23,6 +23,4 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rgeo", "~> 0.5"
 
   spec.add_development_dependency "bundler", "~> 1.6"
-  spec.add_development_dependency "minitest", "~> 5.8"
-  spec.add_development_dependency "rake", "~> 11.0"
 end


### PR DESCRIPTION
- Add Rubocop as a versioned development dependency
- Use bundler for this
- Upgrade Rubocop from implicit 0.35.x to 0.39.x
- Fix new-version Rubocop warnings
- Add Rubocop rake task to default rake task
