### PR TITLE
Added support for bounding box option

### DIFF
--- a/lib/rgeo/geo_json/coder.rb
+++ b/lib/rgeo/geo_json/coder.rb
@@ -70,10 +70,12 @@ module RGeo
 
       def encode(object)
         if @entity_factory.is_feature_collection?(object)
-          {
+          json = {
             "type" => "FeatureCollection",
-            "features" => @entity_factory.map_feature_collection(object) { |f| _encode_feature(f) },
+            "features" => @entity_factory.map_feature_collection(object) { |f| _encode_feature(f) }
           }
+          json["bbox"] = object.bbox if object.bbox
+          json
         elsif @entity_factory.is_feature?(object)
           _encode_feature(object)
         elsif object.nil?
@@ -107,7 +109,7 @@ module RGeo
               decoded_features << _decode_feature(f)
             end
           end
-          @entity_factory.feature_collection(decoded_features)
+          @entity_factory.feature_collection(decoded_features, input["bbox"])
         when "Feature"
           _decode_feature(input)
         else
@@ -132,6 +134,7 @@ module RGeo
         }
         id = @entity_factory.get_feature_id(object)
         json["id"] = id if id
+        json["bbox"] = object.bbox if object.bbox
         json
       end
 
@@ -183,7 +186,7 @@ module RGeo
           geometry = _decode_geometry(geometry)
           return nil unless geometry
         end
-        @entity_factory.feature(geometry, input["id"], input["properties"])
+        @entity_factory.feature(geometry, input["id"], input["properties"], input["bbox"])
       end
 
       def _decode_geometry(input) # :nodoc:

--- a/lib/rgeo/geo_json/entities.rb
+++ b/lib/rgeo/geo_json/entities.rb
@@ -14,17 +14,18 @@ module RGeo
       # Create a feature wrapping the given geometry, with the given ID
       # and properties.
 
-      def initialize(geometry, id = nil, properties = {})
+      def initialize(geometry, id = nil, properties = {}, bbox = nil)
         @geometry = geometry
         @id = id
         @properties = {}
         properties.each do |k, v|
           @properties[k.to_s] = v
         end
+        @bbox = bbox
       end
 
       def inspect
-        "#<#{self.class}:0x#{object_id.to_s(16)} id=#{@id.inspect} geom=#{@geometry ? @geometry.as_text.inspect : 'nil'}>"
+        "#<#{self.class}:0x#{object_id.to_s(16)} id=#{@id.inspect} geom=#{@geometry ? @geometry.as_text.inspect : 'nil'} bbox=#{bbox}>"
       end
 
       def to_s
@@ -56,6 +57,10 @@ module RGeo
       # Returns the geometry contained in this feature, which may be nil.
 
       attr_reader :geometry
+
+      # Returns the bounding box of the feature, which may be nil.
+
+      attr_reader :bbox
 
       # Returns the ID for this feature, which may be nil.
 
@@ -100,9 +105,10 @@ module RGeo
       # Create a new FeatureCollection with the given features, which must
       # be provided as an Enumerable.
 
-      def initialize(features = [])
+      def initialize(features = [], bbox=nil)
         @features = []
         features.each { |f| @features << f if f.is_a?(Feature) }
+        @bbox = bbox
       end
 
       def inspect
@@ -152,6 +158,11 @@ module RGeo
       def [](index)
         @features[index]
       end
+
+      # Returns the bounding box of the feature, which may be nil.
+
+      attr_reader :bbox
+
     end
 
     # This is the default entity factory. It creates objects of type
@@ -163,15 +174,15 @@ module RGeo
       # properties hash. Note that, per the GeoJSON spec, geometry and/or
       # properties may be nil.
 
-      def feature(geometry, id = nil, properties = nil)
-        Feature.new(geometry, id, properties || {})
+      def feature(geometry, id = nil, properties = nil, bbox = nil)
+        Feature.new(geometry, id, properties || {}, bbox)
       end
 
       # Create and return a new feature collection, given an enumerable
       # of feature objects.
 
-      def feature_collection(features = [])
-        FeatureCollection.new(features)
+      def feature_collection(features = [], bbox = nil)
+        FeatureCollection.new(features, bbox)
       end
 
       # Returns true if the given object is a feature created by this

--- a/test/basic_test.rb
+++ b/test/basic_test.rb
@@ -202,8 +202,25 @@ class BasicTest < Minitest::Test # :nodoc:
     assert(RGeo::GeoJSON.decode(json, geo_factory: @geo_factory).eql?(object))
   end
 
+  def test_feature_with_bbox
+    polygon = @geo_factory.polygon(@geo_factory.linear_ring([@geo_factory.point(-10, -10), @geo_factory.point(-10, 10), @geo_factory.point(10,  10), @geo_factory.point(-10, -10)]))
+    object = @entity_factory.feature(polygon, 2, {"prop1" => "foo", "prop2" => "bar"}, [-10.0, -10.0, 10.0, 10.0])
+    json = {
+      "type" => "Feature",
+      "geometry" => {
+        "type" => "Polygon",
+        "coordinates" => [[[-10.0, -10.0], [-10.0, 10.0], [10.0, 10.0], [-10.0, -10.0]]],
+      },
+      "id" => 2,
+      "properties" => { "prop1" => "foo", "prop2" => "bar" },
+      "bbox" => [-10.0, -10.0, 10.0, 10.0]
+    }
+    assert_equal(json, RGeo::GeoJSON.encode(object))
+    assert(RGeo::GeoJSON.decode(json, geo_factory: @geo_factory).eql?(object))
+  end
+
   def test_feature_collection
-    object = @entity_factory.feature_collection([@entity_factory.feature(@geo_factory.point(10, 20)), @entity_factory.feature(@geo_factory.point(11, 22)), @entity_factory.feature(@geo_factory.point(10, 20), 8)])
+    object = @entity_factory.feature_collection([@entity_factory.feature(@geo_factory.point(10, 20)), @entity_factory.feature(@geo_factory.point(11, 22)), @entity_factory.feature(@geo_factory.point(10, 20), 8)], [10.0, 20.0, 11.0, 22.0])
     json = {
       "type" => "FeatureCollection",
       "features" => [
@@ -232,7 +249,8 @@ class BasicTest < Minitest::Test # :nodoc:
           "id" => 8,
           "properties" => {},
         },
-      ]
+      ],
+      "bbox" => [10.0, 20.0, 11.0, 22.0]
     }
     assert_equal(json, RGeo::GeoJSON.encode(object))
     assert(RGeo::GeoJSON.decode(json, geo_factory: @geo_factory).eql?(object))


### PR DESCRIPTION
[GeoJSON specification](http://geojson.org/geojson-spec.html#bounding-boxes) has support for `bbox` option that includes information on the coordinate range for geometries, features, or feature collections
