### PR TITLE
Default to json parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Example:
 require 'rgeo/geo_json'
 
 str1 = '{"type":"Point","coordinates":[1,2]}'
-geom = RGeo::GeoJSON.decode(str1, json_parser: :json)
+geom = RGeo::GeoJSON.decode(str1)
 geom.as_text              # => "POINT(1.0 2.0)"
 
 str2 = '{"type":"Feature","geometry":{"type":"Point","coordinates":[2.5,4.0]},"properties":{"color":"red"}}'

--- a/lib/rgeo/geo_json/coder.rb
+++ b/lib/rgeo/geo_json/coder.rb
@@ -37,17 +37,19 @@ module RGeo
         @entity_factory = opts[:entity_factory] || EntityFactory.instance
         @json_parser = opts[:json_parser]
         case @json_parser
+        when :json, nil
+          require "json" unless defined?(JSON)
+          @json_parser = proc { |str| JSON.parse(str) }
         when :yajl
           require "yajl" unless defined?(Yajl)
           @json_parser = proc { |str| Yajl::Parser.new.parse(str) }
         when :active_support
           require "active_support/json" unless defined?(ActiveSupport::JSON)
           @json_parser = proc { |str| ActiveSupport::JSON.decode(str) }
-        when Proc, nil
+        when Proc
           # Leave as is
         else
-          require "json" unless defined?(JSON)
-          @json_parser = proc { |str| JSON.parse(str) }
+          raise ::ArgumentError, "Unrecognzied json_parser: #{@json_parser.inspect}"
         end
         @num_coordinates = 2
         @num_coordinates += 1 if @geo_factory.property(:has_z_coordinate)

--- a/lib/rgeo/geo_json/coder.rb
+++ b/lib/rgeo/geo_json/coder.rb
@@ -29,8 +29,6 @@ module RGeo
       #   will require the corresponding library to be available. Note
       #   that the <tt>:json</tt> library is present in the standard
       #   library in Ruby 1.9.
-      #   If a parser is not specified, then the decode method will not
-      #   accept a String or IO object; it will require a Hash.
 
       def initialize(opts = {})
         @geo_factory = opts[:geo_factory] || RGeo::Cartesian.preferred_factory

--- a/lib/rgeo/geo_json/coder.rb
+++ b/lib/rgeo/geo_json/coder.rb
@@ -37,9 +37,6 @@ module RGeo
         @entity_factory = opts[:entity_factory] || EntityFactory.instance
         @json_parser = opts[:json_parser]
         case @json_parser
-        when :json
-          require "json" unless defined?(JSON)
-          @json_parser = proc { |str| JSON.parse(str) }
         when :yajl
           require "yajl" unless defined?(Yajl)
           @json_parser = proc { |str| Yajl::Parser.new.parse(str) }
@@ -49,7 +46,8 @@ module RGeo
         when Proc, nil
           # Leave as is
         else
-          raise ::ArgumentError, "Unrecognzied json_parser: #{@json_parser.inspect}"
+          require "json" unless defined?(JSON)
+          @json_parser = proc { |str| JSON.parse(str) }
         end
         @num_coordinates = 2
         @num_coordinates += 1 if @geo_factory.property(:has_z_coordinate)


### PR DESCRIPTION
The standard lib json parser is [good enough](http://www.mikeperham.com/2016/02/09/kill-your-dependencies/) - and this definitely shouldn't be a required parameter.

And then, it swallows the error? Doesn't make sense to me. Frankly, to me, this entire bit should be removed and you should just parse with the standard lib if you get a string (ruby < 1.9 can figure it out themselves - particularly if there was an error thrown - oh wait, you require 1.9.3 so that doesn't even matter).

But in the interest of not making a major modification - it's already checking the type, why raise an error if it's a string? Why not just make life better and just work?