### PR TITLE
Add delegation to geometry in Feature

### DIFF
--- a/.rdoc_options
+++ b/.rdoc_options
@@ -1,0 +1,23 @@
+--- !ruby/object:RDoc::Options
+encoding: UTF-8
+static_path: []
+rdoc_include:
+- "."
+- "/Users/ulysse/Dev/rgeo/rgeo-geojson"
+charset: UTF-8
+exclude: !ruby/regexp /~\z|\.orig\z|\.rej\z|\.bak\z|\.gemspec\z/
+hyperlink_all: false
+line_numbers: false
+locale:
+locale_dir: locale
+locale_name:
+main_page:
+markup: markdown
+output_decoration: true
+page_dir:
+show_hash: false
+tab_width: 8
+template_stylesheets: []
+title:
+visibility: :protected
+webcvs:

--- a/History.md
+++ b/History.md
@@ -1,3 +1,8 @@
+### Ongoing
+
+* Delegation to inner geometry for a feature (#53)
+* MultiJson rather than JSON (#46)
+
 ### 2.1.1 / 2018-11-27
 
 * Freeze strings

--- a/lib/rgeo-geojson.rb
+++ b/lib/rgeo-geojson.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-require "rgeo/geo_json"
+require_relative "rgeo/geo_json"

--- a/lib/rgeo/geo_json.rb
+++ b/lib/rgeo/geo_json.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 require "rgeo"
-require "rgeo/geo_json/version"
-require "rgeo/geo_json/entities"
-require "rgeo/geo_json/coder"
-require "rgeo/geo_json/interface"
+require_relative "geo_json/version"
+require_relative "geo_json/entities"
+require_relative "geo_json/coder"
+require_relative "geo_json/interface"
 require "multi_json"

--- a/lib/rgeo/geo_json/coder.rb
+++ b/lib/rgeo/geo_json/coder.rb
@@ -6,7 +6,6 @@ module RGeo
     # the RGeo::Feature::Factory and the RGeo::GeoJSON::EntityFactory to
     # be used) so that you can encode and decode without specifying those
     # settings every time.
-
     class Coder
       # Create a new coder settings object. The geo factory is passed as
       # a required argument.
@@ -41,7 +40,6 @@ module RGeo
       # appropriate JSON library installed.
       #
       # Returns nil if nil is passed in as the object.
-
       def encode(object)
         if @entity_factory.is_feature_collection?(object)
           {
@@ -60,7 +58,6 @@ module RGeo
       # Decode an object from GeoJSON. The input may be a JSON hash, a
       # String, or an IO object from which to read the JSON string.
       # If an error occurs, nil is returned.
-
       def decode(input)
         if input.is_a?(IO)
           input = input.read rescue nil

--- a/lib/rgeo/geo_json/collection_methods.rb
+++ b/lib/rgeo/geo_json/collection_methods.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module RGeo
+  # This module is here to fill the gap between what is a GeometryCollection (GIS)
+  # and a FeatureCollection (GeoJSON).
+  #
+  # Note for contributors, you can rely on `@features` to be defined and
+  # you can consider working with an Enumerable wrapping `@features`. See
+  # GeoJSON::FeatureCollection.
+  module GeoJSON::CollectionMethods
+    # There is tight coupling between {FeatureCollection} and this, hence the
+    # guard.
+    private_class_method def self.included(base)
+      return if base.to_s == "RGeo::GeoJSON::FeatureCollection"
+
+      raise Error::RGeoError, "#{self.class} must only be used by FeatureCollection"
+    end
+
+    private def method_missing(symbol, *args)
+      return super unless any? { |feature| feature.respond_to?(symbol) }
+
+      raise Error::UnsupportedOperation, "Method FeatureCollection##{symbol} " \
+        "is not defined. You may consider filing an issue or opening a pull " \
+        "request at https://github.com/rgeo/rgeo-geojson"
+    end
+
+    def contains?(geometry)
+      any? { |feature| feature.contains?(geometry) }
+    end
+
+    def intersects?(geometry)
+      any? { |feature| feature.intersects?(geometry) }
+    end
+  end
+end

--- a/lib/rgeo/geo_json/entities.rb
+++ b/lib/rgeo/geo_json/entities.rb
@@ -103,7 +103,6 @@ module RGeo
     # duck-type this class. The entity factory mediates all interaction
     # between the GeoJSON engine and feature collections.
     class FeatureCollection
-      include DelegateToGeometry
       include Enumerable
 
       # Create a new FeatureCollection with the given features, which must
@@ -116,17 +115,6 @@ module RGeo
 
       def inspect
         "#<#{self.class}:0x#{object_id.to_s(16)}>"
-      end
-
-      # Similar to {RGeo::GeoJSON#geometry}, returns the inner geometries as
-      # a geometry collection. It can be nil if there are no features.
-      def geometry
-        return @geometry if defined?(@geometry)
-        return @geometry = nil if @features.empty?
-
-        @geometry = @features.first.factory.collection(
-          @features.map(&:geometry)
-        ).freeze
       end
 
       def to_s

--- a/lib/rgeo/geo_json/entities.rb
+++ b/lib/rgeo/geo_json/entities.rb
@@ -3,6 +3,22 @@
 require_relative "collection_methods"
 
 module RGeo
+  module CastOverlay
+    def self.included(base)
+      # The original {RGeo::Feature.cast} would copy a GeoJSON::Feature, which
+      # fails most operations. When casting, we MUST get a geometry.
+      original_cast = base.method(:cast)
+      base.define_singleton_method(:cast) do |obj, *params|
+        if obj.class == GeoJSON::Feature
+          original_cast.call(obj.geometry, *params)
+        else
+          original_cast.call(obj, *params)
+        end
+      end
+    end
+  end
+  Feature.include(CastOverlay)
+
   module GeoJSON
     # Simplify usage of inner geometries for Feature and FeatureCollection
     # objets. Including class must contain a `#geometry` method.

--- a/lib/rgeo/geo_json/entities.rb
+++ b/lib/rgeo/geo_json/entities.rb
@@ -1,17 +1,19 @@
 # frozen_string_literal: true
 
+require_relative "collection_methods"
+
 module RGeo
   module GeoJSON
     # Simplify usage of inner geometries for Feature and FeatureCollection
     # objets. Including class must contain a `#geometry` method.
     module DelegateToGeometry
-      def method_missing(symbol, *args)
+      private def method_missing(symbol, *args)
         return geometry.public_send(symbol, *args) if geometry
 
         super
       end
 
-      def respond_to_missing?(symbol, *)
+      private def respond_to_missing?(symbol, *)
         geometry&.respond_to?(symbol) || super
       end
     end
@@ -104,6 +106,7 @@ module RGeo
     # between the GeoJSON engine and feature collections.
     class FeatureCollection
       include Enumerable
+      include CollectionMethods
 
       # Create a new FeatureCollection with the given features, which must
       # be provided as an Enumerable.

--- a/lib/rgeo/geo_json/interface.rb
+++ b/lib/rgeo/geo_json/interface.rb
@@ -13,9 +13,8 @@ module RGeo
       # RGeo::GeoJSON::EntityFactory for more information. By default,
       # encode supports objects of type RGeo::GeoJSON::Feature and
       # RGeo::GeoJSON::FeatureCollection.
-
       def encode(object, opts = {})
-        Coder.new(opts).encode(object)
+        coder(opts).encode(object)
       end
 
       # High-level convenience routine for decoding an object from GeoJSON.
@@ -33,8 +32,8 @@ module RGeo
       #   RGeo::GeoJSON::EntityFactory, which generates objects of type
       #   RGeo::GeoJSON::Feature or RGeo::GeoJSON::FeatureCollection.
       #   See RGeo::GeoJSON::EntityFactory for more information.
-      def decode(input_, opts = {})
-        Coder.new(opts).decode(input_)
+      def decode(input, opts = {})
+        coder(opts).decode(input)
       end
 
       # Creates and returns a coder object of type RGeo::GeoJSON::Coder

--- a/test/basic_test.rb
+++ b/test/basic_test.rb
@@ -257,7 +257,6 @@ class BasicTest < Minitest::Test # :nodoc:
         },
       ]
     }
-    assert_equal(object.geometry, @geo_factory.collection(geometries))
     assert_equal(json, RGeo::GeoJSON.encode(object))
     assert(RGeo::GeoJSON.decode(json, geo_factory: @geo_factory).eql?(object))
   end
@@ -268,7 +267,6 @@ class BasicTest < Minitest::Test # :nodoc:
       "type" => "FeatureCollection",
       "features" => []
     }
-    assert_nil(object.geometry)
     assert_equal(json, RGeo::GeoJSON.encode(object))
     assert(RGeo::GeoJSON.decode(json, geo_factory: @geo_factory).eql?(object))
   end

--- a/test/basic_test.rb
+++ b/test/basic_test.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 require "minitest/autorun"
-require "rgeo/geo_json"
-
+require_relative "../lib/rgeo-geojson"
 class BasicTest < Minitest::Test # :nodoc:
   def setup
     @geo_factory = RGeo::Cartesian.simple_factory(srid: 4326)
@@ -179,10 +178,10 @@ class BasicTest < Minitest::Test # :nodoc:
   def test_feature_nulls
     feature = @entity_factory.feature(nil, nil, nil)
     json = RGeo::GeoJSON.encode(feature)
-    obj_ = RGeo::GeoJSON.decode(json, geo_factory: @geo_factory)
-    refute_nil(obj_)
-    assert_nil(obj_.geometry)
-    assert_equal({}, obj_.properties)
+    obj = RGeo::GeoJSON.decode(json, geo_factory: @geo_factory)
+    refute_nil(obj)
+    assert_nil(obj.geometry)
+    assert_equal({}, obj.properties)
   end
 
   def test_feature_complex
@@ -218,7 +217,16 @@ class BasicTest < Minitest::Test # :nodoc:
   end
 
   def test_feature_collection
-    object = @entity_factory.feature_collection([@entity_factory.feature(@geo_factory.point(10, 20)), @entity_factory.feature(@geo_factory.point(11, 22)), @entity_factory.feature(@geo_factory.point(10, 20), 8)])
+    geometries = [
+      @geo_factory.point(10, 20),
+      @geo_factory.point(11, 22),
+      @geo_factory.point(10, 20)
+    ]
+    object = @entity_factory.feature_collection([
+      @entity_factory.feature(geometries[0]),
+      @entity_factory.feature(geometries[1]),
+      @entity_factory.feature(geometries[2], 8)
+    ])
     json = {
       "type" => "FeatureCollection",
       "features" => [
@@ -249,6 +257,18 @@ class BasicTest < Minitest::Test # :nodoc:
         },
       ]
     }
+    assert_equal(object.geometry, @geo_factory.collection(geometries))
+    assert_equal(json, RGeo::GeoJSON.encode(object))
+    assert(RGeo::GeoJSON.decode(json, geo_factory: @geo_factory).eql?(object))
+  end
+
+  def test_feature_collection_empty
+    object = @entity_factory.feature_collection([])
+    json = {
+      "type" => "FeatureCollection",
+      "features" => []
+    }
+    assert_nil(object.geometry)
     assert_equal(json, RGeo::GeoJSON.encode(object))
     assert(RGeo::GeoJSON.decode(json, geo_factory: @geo_factory).eql?(object))
   end

--- a/test/basic_test.rb
+++ b/test/basic_test.rb
@@ -276,4 +276,11 @@ class BasicTest < Minitest::Test # :nodoc:
     assert_equal "b", feature.properties["a"]
     assert_equal "b", feature["a"]
   end
+
+  def test_feature_cast
+    factory = RGeo::Cartesian.factory(srid: 4326)
+    poly = factory.polygon(factory.linear_ring([factory.point(0, 0), factory.point(10, 0), factory.point(10, 10), factory.point(0, 10), factory.point(0, 0)]))
+    point_feature = RGeo::GeoJSON::Feature.new(factory.point(1, 1))
+    assert poly.contains?(point_feature)
+  end
 end

--- a/test/geometry_usage_test.rb
+++ b/test/geometry_usage_test.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require_relative "../lib/rgeo-geojson"
+
+class GeometryUsageTest < Minitest::Test # :nodoc:
+  def setup
+    @geo_factory = RGeo::Cartesian.simple_factory
+  end
+
+  def test_feature_uses_method_missing
+    json = {
+      "type" => "Feature",
+      "geometry" => {
+        "type" => "Polygon",
+        "coordinates" => [[[10.0, 20.0], [12.0, 22.0], [-3.0, 24.0], [10.0, 20.0]]]
+      }
+    }
+    rgeo_feature = RGeo::GeoJSON.decode(json, geo_factory: @geo_factory)
+    pt = @geo_factory.point([10.0, 14.0].sample, [20.0, 25.0].sample)
+
+    assert_equal(
+      rgeo_feature.contains?(pt),
+      rgeo_feature.geometry.contains?(pt)
+    )
+  end
+
+  def test_feature_collection_uses_method_missing
+    json = {
+      "type" => "FeatureCollection",
+      "features" => [
+        {
+          "type" => "Feature",
+          "geometry" => {
+            "type" => "Polygon",
+            "coordinates" => [[[10.0, 20.0], [12.0, 22.0], [-3.0, 24.0], [10.0, 20.0]]],
+          },
+          "properties" => {},
+        }
+      ]
+    }
+    rgeo_feature_collection = RGeo::GeoJSON.decode(json, geo_factory: @geo_factory)
+    pt = @geo_factory.point([10.0, 14.0].sample, [20.0, 25.0].sample)
+    assert_equal(
+      rgeo_feature_collection.as_text,
+      rgeo_feature_collection.geometry.as_text
+    )
+  end
+end

--- a/test/geometry_usage_test.rb
+++ b/test/geometry_usage_test.rb
@@ -5,7 +5,7 @@ require_relative "../lib/rgeo-geojson"
 
 class GeometryUsageTest < Minitest::Test # :nodoc:
   def setup
-    @geo_factory = RGeo::Cartesian.simple_factory
+    @geo_factory = RGeo::Cartesian.factory
   end
 
   def test_feature_uses_method_missing
@@ -27,5 +27,47 @@ class GeometryUsageTest < Minitest::Test # :nodoc:
       rgeo_feature.as_text,
       rgeo_feature.geometry.as_text
     )
+  end
+
+  def test_collection_contains?
+    skip "`#contains?` is not defined in pure ruby" unless RGeo::Geos.capi_supported?
+
+    collection = polygon_and_point_collection
+
+    assert collection.contains? @geo_factory.point(5.0, 6.0)
+  end
+
+  def test_collection_intersects?
+    skip "`#intersects?`` is not defined in pure ruby" unless RGeo::Geos.capi_supported?
+
+    collection = polygon_and_point_collection
+
+    assert collection.intersects? @geo_factory.point(5.0, 6.0)
+  end
+
+  private
+
+  def polygon_and_point_collection
+    RGeo::GeoJSON.decode({
+      "type" => "FeatureCollection",
+      "features" => [
+        {
+          "type" => "Feature",
+          "geometry" => {
+            "type" => "Point",
+            "coordinates" => [10.0, 20.0],
+          },
+          "properties" => {},
+        },
+        {
+          "type" => "Feature",
+          "geometry" => {
+            "type" => "Polygon",
+            "coordinates" => [[[0.0, 0.0], [10.0, 10.0], [0.0, 10.0], [0.0, 0.0]]],
+          },
+          "properties" => {},
+        }
+      ]
+    }, geo_factory: @geo_factory)
   end
 end

--- a/test/geometry_usage_test.rb
+++ b/test/geometry_usage_test.rb
@@ -23,27 +23,9 @@ class GeometryUsageTest < Minitest::Test # :nodoc:
       rgeo_feature.contains?(pt),
       rgeo_feature.geometry.contains?(pt)
     )
-  end
-
-  def test_feature_collection_uses_method_missing
-    json = {
-      "type" => "FeatureCollection",
-      "features" => [
-        {
-          "type" => "Feature",
-          "geometry" => {
-            "type" => "Polygon",
-            "coordinates" => [[[10.0, 20.0], [12.0, 22.0], [-3.0, 24.0], [10.0, 20.0]]],
-          },
-          "properties" => {},
-        }
-      ]
-    }
-    rgeo_feature_collection = RGeo::GeoJSON.decode(json, geo_factory: @geo_factory)
-    pt = @geo_factory.point([10.0, 14.0].sample, [20.0, 25.0].sample)
     assert_equal(
-      rgeo_feature_collection.as_text,
-      rgeo_feature_collection.geometry.as_text
+      rgeo_feature.as_text,
+      rgeo_feature.geometry.as_text
     )
   end
 end


### PR DESCRIPTION
Both entities Feature and FeatureCollection are now provided a
`method_missing` that will default to inner geometry.

CAVEATS: The inner geometry for a FeatureCollection is a
GeometryCollection which is not exactly true, but a simpler solution
for RGeo compatibility. We can still override methods that behave
poorly directly in `RGeo::GeoJSON::FeatureCollection`.

This feature helps refactor code like [this one](https://github.com/rgeo/rgeo-geojson/issues/34#issuecomment-721990270), and is in [RGeo 3.0 roadmap](https://github.com/rgeo/rgeo/issues/247). To make the `contains?` example cleaner, we could also add a `contains?` method in the `BasicGeometryCollectionMethods` module in rgeo.

```patch
diff --git a/lib/rgeo/impl_helper/basic_geometry_collection_methods.rb b/lib/rgeo/impl_helper/basic_geometry_collection_methods.rb
index fd6a819..67578de 100644
--- a/lib/rgeo/impl_helper/basic_geometry_collection_methods.rb
+++ b/lib/rgeo/impl_helper/basic_geometry_collection_methods.rb
@@ -29,6 +29,10 @@ module RGeo
         n < 0 ? nil : @elements[n]
       end
 
+      def contains?(other_geometry)
+        geometries.any? { |geometry| geometry.contains?(other_geometry) }
+      end
+
       def [](n)
         @elements[n]
       end
 