### PR TITLE
Avoid multi_json deprecation warnings on 1.21+

### DIFF
--- a/lib/rgeo/geo_json.rb
+++ b/lib/rgeo/geo_json.rb
@@ -7,3 +7,29 @@ require_relative "geo_json/entities"
 require_relative "geo_json/coder"
 require_relative "geo_json/interface"
 require "multi_json"
+
+module RGeo
+  module GeoJSON
+    # Thin shim over multi_json that picks the canonical constant and
+    # method names available at load time. multi_json 1.21 renamed
+    # `MultiJson` -> `MultiJSON` and `load`/`dump` -> `parse`/`generate`;
+    # the legacy names still work but each emit a one-shot deprecation
+    # warning. Resolving the dispatch once at require time avoids the
+    # warnings on 1.21+ while staying compatible with the existing
+    # `~> 1.15` dependency floor.
+    module JsonAdapter
+      ADAPTER = defined?(::MultiJSON) ? ::MultiJSON : ::MultiJson
+      private_constant :ADAPTER
+
+      module_function
+
+      if ADAPTER.respond_to?(:generate)
+        def generate(object) = ADAPTER.generate(object)
+        def parse(string) = ADAPTER.parse(string)
+      else
+        def generate(object) = ADAPTER.dump(object)
+        def parse(string) = ADAPTER.load(string)
+      end
+    end
+  end
+end

--- a/lib/rgeo/geo_json.rb
+++ b/lib/rgeo/geo_json.rb
@@ -2,34 +2,8 @@
 
 require "rgeo"
 require_relative "geo_json/version"
+require_relative "geo_json/json_adapter"
 require_relative "geo_json/conversion_methods"
 require_relative "geo_json/entities"
 require_relative "geo_json/coder"
 require_relative "geo_json/interface"
-require "multi_json"
-
-module RGeo
-  module GeoJSON
-    # Thin shim over multi_json that picks the canonical constant and
-    # method names available at load time. multi_json 1.21 renamed
-    # `MultiJson` -> `MultiJSON` and `load`/`dump` -> `parse`/`generate`;
-    # the legacy names still work but each emit a one-shot deprecation
-    # warning. Resolving the dispatch once at require time avoids the
-    # warnings on 1.21+ while staying compatible with the existing
-    # `~> 1.15` dependency floor.
-    module JsonAdapter
-      ADAPTER = defined?(::MultiJSON) ? ::MultiJSON : ::MultiJson
-      private_constant :ADAPTER
-
-      module_function
-
-      if ADAPTER.respond_to?(:generate)
-        def generate(object) = ADAPTER.generate(object)
-        def parse(string) = ADAPTER.parse(string)
-      else
-        def generate(object) = ADAPTER.dump(object)
-        def parse(string) = ADAPTER.load(string)
-      end
-    end
-  end
-end

--- a/lib/rgeo/geo_json/coder.rb
+++ b/lib/rgeo/geo_json/coder.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "json_adapter"
+
 module RGeo
   module GeoJSON
     # This object encapsulates encoding and decoding settings (principally

--- a/lib/rgeo/geo_json/coder.rb
+++ b/lib/rgeo/geo_json/coder.rb
@@ -63,7 +63,7 @@ module RGeo
           input = input.read rescue nil
         end
         if input.is_a?(String)
-          input = MultiJson.load(input)
+          input = RGeo::GeoJSON::JsonAdapter.parse(input)
         end
         return unless input.is_a?(Hash)
 

--- a/lib/rgeo/geo_json/conversion_methods.rb
+++ b/lib/rgeo/geo_json/conversion_methods.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "json_adapter"
+
 module RGeo
   # This module serves to provide handy methods when using GeoJSON. The methods
   # provided eases the passage between entities and GeoJSON String/Hash.

--- a/lib/rgeo/geo_json/conversion_methods.rb
+++ b/lib/rgeo/geo_json/conversion_methods.rb
@@ -12,7 +12,7 @@ module RGeo
 
     # Convert a geometry to a GeoJSON String
     def to_geojson
-      ::MultiJson.dump(as_geojson)
+      RGeo::GeoJSON::JsonAdapter.generate(as_geojson)
     end
     alias to_json to_geojson
   end
@@ -33,7 +33,7 @@ module RGeo
 
       # Convert a geometry to a GeoJSON String
       def to_geojson
-        ::MultiJson.dump(as_geojson)
+        RGeo::GeoJSON::JsonAdapter.generate(as_geojson)
       end
       alias to_json to_geojson
     end

--- a/lib/rgeo/geo_json/json_adapter.rb
+++ b/lib/rgeo/geo_json/json_adapter.rb
@@ -14,27 +14,25 @@ module RGeo
     #
     # `options` mirrors multi_json's own signature (positional hash with
     # default `{}`) and is forwarded unchanged, so callers can pass any
-    # adapter-supported option (e.g. `:symbolize_keys`) through.
+    # adapter-supported option (e.g. `:symbolize_names`) through.
     module JsonAdapter
       ADAPTER = defined?(::MultiJSON) ? ::MultiJSON : ::MultiJson
       private_constant :ADAPTER
 
-      module_function
-
       if ADAPTER.respond_to?(:generate) && ADAPTER.respond_to?(:parse)
-        def generate(object, options = {})
+        def self.generate(object, options = {})
           ADAPTER.generate(object, options)
         end
 
-        def parse(string, options = {})
+        def self.parse(string, options = {})
           ADAPTER.parse(string, options)
         end
       else
-        def generate(object, options = {})
+        def self.generate(object, options = {})
           ADAPTER.dump(object, options)
         end
 
-        def parse(string, options = {})
+        def self.parse(string, options = {})
           ADAPTER.load(string, options)
         end
       end

--- a/lib/rgeo/geo_json/json_adapter.rb
+++ b/lib/rgeo/geo_json/json_adapter.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "multi_json"
+
+module RGeo
+  module GeoJSON
+    # Thin shim over multi_json that picks the canonical constant and
+    # method names available at load time. multi_json 1.21 renamed
+    # `MultiJson` -> `MultiJSON` and `load`/`dump` -> `parse`/`generate`;
+    # the legacy names still work but each emit a one-shot deprecation
+    # warning. Resolving the dispatch once at require time avoids the
+    # warnings on 1.21+ while staying compatible with the existing
+    # `~> 1.15` dependency floor.
+    #
+    # `options` mirrors multi_json's own signature (positional hash with
+    # default `{}`) and is forwarded unchanged, so callers can pass any
+    # adapter-supported option (e.g. `:symbolize_keys`) through.
+    module JsonAdapter
+      ADAPTER = defined?(::MultiJSON) ? ::MultiJSON : ::MultiJson
+      private_constant :ADAPTER
+
+      module_function
+
+      if ADAPTER.respond_to?(:generate) && ADAPTER.respond_to?(:parse)
+        def generate(object, options = {})
+          ADAPTER.generate(object, options)
+        end
+
+        def parse(string, options = {})
+          ADAPTER.parse(string, options)
+        end
+      else
+        def generate(object, options = {})
+          ADAPTER.dump(object, options)
+        end
+
+        def parse(string, options = {})
+          ADAPTER.load(string, options)
+        end
+      end
+    end
+  end
+end

--- a/test/json_adapter_test.rb
+++ b/test/json_adapter_test.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "rbconfig"
+
+class JsonAdapterDirectRequireTest < Minitest::Test # :nodoc:
+  # Regression test for https://github.com/rgeo/rgeo-geojson/pull/64
+  #
+  # Files under lib/rgeo/geo_json/ that route JSON I/O through JsonAdapter
+  # must require it themselves, so a consumer requiring (for example) just
+  # `rgeo/geo_json/conversion_methods` directly — on top of `rgeo` — does
+  # not blow up with NameError on first call. We shell out to a fresh Ruby
+  # process so the assertion isn't masked by the rest of the test suite
+  # having already loaded the parent `rgeo/geo_json` file.
+
+  def test_conversion_methods_loads_json_adapter
+    assert_loads_json_adapter("rgeo/geo_json/conversion_methods")
+  end
+
+  def test_coder_loads_json_adapter
+    assert_loads_json_adapter("rgeo/geo_json/coder")
+  end
+
+  private
+
+  def assert_loads_json_adapter(leaf_path)
+    lib_dir = File.expand_path("../lib", __dir__)
+    script = <<~RUBY
+      require "bundler/setup"
+      $LOAD_PATH.unshift(#{lib_dir.inspect})
+      require "rgeo"
+      require #{leaf_path.inspect}
+      raise "JsonAdapter not defined" unless defined?(RGeo::GeoJSON::JsonAdapter)
+      raise "generate missing" unless RGeo::GeoJSON::JsonAdapter.respond_to?(:generate)
+      raise "parse missing" unless RGeo::GeoJSON::JsonAdapter.respond_to?(:parse)
+      puts "ok"
+    RUBY
+    output = IO.popen([RbConfig.ruby, "-e", script], err: [:child, :out], &:read)
+    assert_equal "ok", output.strip,
+      "Direct require of #{leaf_path} broke JsonAdapter availability:\n#{output}"
+  end
+end

--- a/test/json_adapter_test.rb
+++ b/test/json_adapter_test.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 require "minitest/autorun"
+require "open3"
 require "rbconfig"
+require_relative "../lib/rgeo-geojson"
 
 class JsonAdapterDirectRequireTest < Minitest::Test # :nodoc:
   # Regression test for https://github.com/rgeo/rgeo-geojson/pull/64
@@ -35,8 +37,41 @@ class JsonAdapterDirectRequireTest < Minitest::Test # :nodoc:
       raise "parse missing" unless RGeo::GeoJSON::JsonAdapter.respond_to?(:parse)
       puts "ok"
     RUBY
-    output = IO.popen([RbConfig.ruby, "-e", script], err: [:child, :out], &:read)
-    assert_equal "ok", output.strip,
-      "Direct require of #{leaf_path} broke JsonAdapter availability:\n#{output}"
+    output, status = Open3.capture2e(RbConfig.ruby, "-e", script)
+    assert status.success?,
+      "Direct require of #{leaf_path} returned non-zero exit:\n#{output}"
+    assert_equal "ok", output.rstrip.lines.last.to_s.strip,
+      "Direct require of #{leaf_path} did not emit 'ok' as final line:\n#{output}"
+  end
+end
+
+class JsonAdapterDispatchTest < Minitest::Test # :nodoc:
+  # Exercises the runtime dispatch path that JsonAdapter wires up at load
+  # time. Guards both the constant/method-name selection (MultiJson vs
+  # MultiJSON, load/dump vs parse/generate) and the positional options
+  # forwarding contract.
+
+  def test_roundtrip
+    original = { "type" => "Point", "coordinates" => [1.0, 2.0] }
+    encoded = RGeo::GeoJSON::JsonAdapter.generate(original)
+    assert_kind_of String, encoded
+    assert_equal original, RGeo::GeoJSON::JsonAdapter.parse(encoded)
+  end
+
+  def test_options_forwarded_to_underlying_adapter
+    # Control: without the option, keys arrive as strings — establishes
+    # that the option in the next assertion is what flipped the behavior.
+    assert_equal({ "a" => 1 }, RGeo::GeoJSON::JsonAdapter.parse(%({"a":1})))
+    assert_equal({ a: 1 }, RGeo::GeoJSON::JsonAdapter.parse(%({"a":1}), symbolize_key_option => true))
+  end
+
+  private
+
+  # multi_json renamed `:symbolize_keys` -> `:symbolize_names` in 1.21.
+  # Pick whichever name the underlying adapter understands so the test
+  # runs cleanly on both `multi_json ~> 1.15` and `~> 1.21`.
+  def symbolize_key_option
+    adapter = defined?(::MultiJSON) ? ::MultiJSON : ::MultiJson
+    adapter.respond_to?(:parse) ? :symbolize_names : :symbolize_keys
   end
 end


### PR DESCRIPTION
## Problem

`multi_json` 1.21 renamed both the canonical module (`MultiJson` → `MultiJSON`) and the load/dump API (`load`/`dump` → `parse`/`generate`). The legacy names still resolve but emit one-shot deprecation warnings every time they are referenced. With `rgeo-geojson` 2.2.0 + `multi_json` 1.21 in the bundle, a host app sees three warnings before it has finished booting:

```
The MultiJson constant is deprecated and will be removed in v2.0. Use MultiJSON instead.
MultiJSON.dump is deprecated and will be removed in v2.0. Use MultiJSON.generate instead.
MultiJSON.load is deprecated and will be removed in v2.0. Use MultiJSON.parse instead.
```

## Fix

Introduce a small `RGeo::GeoJSON::JsonAdapter` shim that resolves the right constant and method names **once at require time**:

- `defined?(::MultiJSON) ? ::MultiJSON : ::MultiJson`
- `respond_to?(:generate) ? :generate / :parse : :dump / :load`

The three call sites in `conversion_methods.rb` and `coder.rb` route through the shim instead of touching `MultiJson` directly.

## Compatibility

- **Backwards-compatible** with the existing `multi_json ~> 1.15` gemspec floor — older versions only define `:load`/`:dump` on `MultiJson`, which the fallback branch handles.
- **Forward-compatible** with `multi_json` 2.0 — once the legacy names are removed, the fallback branch becomes dead code and can be deleted.

## Tests

Full suite passes against master baseline (`bundle exec rake test`). No new failures introduced; the only pre-existing errors in a local run are GEOS-infrastructure issues unrelated to this change. Also verified manually with a Point/Feature round-trip on `multi_json` 1.21.1 — all three deprecation lines disappear and the GeoJSON output is byte-identical to current `master`.